### PR TITLE
Bugfix from XCode10.1 crash 

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.h
+++ b/XLForm/XL/Controllers/XLFormViewController.h
@@ -82,6 +82,7 @@ typedef NS_ENUM(NSUInteger, XLFormRowNavigationDirection) {
 
 @property XLFormDescriptor * form;
 @property IBOutlet UITableView * tableView;
+@property NSString * moduleName;
 
 -(id)initWithForm:(XLFormDescriptor *)form;
 -(id)initWithForm:(XLFormDescriptor *)form style:(UITableViewStyle)style;

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -127,7 +127,7 @@
             } else {
               Class cellClassActual = NSClassFromString(cellClassString);
               if (cellClassActual == nil) {
-                // On XCode10.1 for iOS11 the module prefix is not provided so provide it here if it's missing
+                NSAssert([formController moduleName] != nil, @"self.moduleName is not set on XLFormViewController subclass.");
                 cellClassActual = NSClassFromString([NSString stringWithFormat: @"%@.%@", [formController moduleName], cellClassString]);
               }
               bundle = [NSBundle bundleForClass: cellClassActual];

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -125,8 +125,13 @@
                 NSString *bundlePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:folderName];
                 bundle = [NSBundle bundleWithPath:bundlePath];
             } else {
-                bundle = [NSBundle bundleForClass:NSClassFromString(cellClass)];
-                cellResource = cellClassString;
+              Class cellClassActual = NSClassFromString(cellClassString);
+              if (cellClassActual == nil) {
+                // On XCode10.1 for iOS11 the module prefix is not provided so provide it here if it's missing
+                cellClassActual = NSClassFromString([NSString stringWithFormat: @"%@.%@", [formController moduleName], cellClassString]);
+              }
+              bundle = [NSBundle bundleForClass: cellClassActual];
+              cellResource = cellClassString;
             }
             NSParameterAssert(bundle != nil);
             NSParameterAssert(cellResource != nil);


### PR DESCRIPTION
XCode10.1 crashing in XLForm on physical devices on iOS11 and below.. The problem is that `NSClassFromString(cellClass)];` was returning nil because the module prefix string was not being added. The solution to this is to add the module prefix string if `NSClassFromString(cellClass)];` returns nil. The `moduleName` can be added in the `XLFormViewController` subclass. Crash report below.

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x20)
    frame #0: 0x0000000106ecc7d0 libswiftCore.dylib`patchedBundleForClass(objc_object*, objc_selector*, objc_class*) + 24
  * frame #1: 0x00000001067a8eb4 XLForm`-[XLFormRowDescriptor cellForFormController:](self=0x000000017459a5b0, _cmd="cellForFormController:", formController=0x000000010e74b9d0) at XLFormRowDescriptor.m:132
    frame #2: 0x00000001067cff3c XLForm`-[XLFormViewController tableView:estimatedHeightForRowAtIndexPath:](self=0x000000010e74b9d0, _cmd="tableView:estimatedHeightForRowAtIndexPath:", tableView=0x0000000108a8b000, indexPath=0xc000000000400016) at XLFormViewController.m:729
    frame #3: 0x000000019825f9ac UIKit`-[UITableView _estimatedHeightForRowAtIndexPath:] + 116
    frame #4: 0x0000000198031654 UIKit`__66-[UISectionRowData refreshWithSection:tableView:tableViewRowData:]_block_invoke + 328
    frame #5: 0x0000000197ff1bd8 UIKit`-[UISectionRowData refreshWithSection:tableView:tableViewRowData:] + 2608
    frame #6: 0x000000019810cdc0 UIKit`-[UITableViewRowData ensureAllSectionsAreValid] + 152
    frame #7: 0x00000001980f0848 UIKit`-[UITableView _endCellAnimationsWithContext:] + 532
    frame #8: 0x00000001067ca4e4 XLForm`-[XLFormViewController formRowHasBeenAdded:atIndexPath:](self=0x000000010e74b9d0, _cmd="formRowHasBeenAdded:atIndexPath:", formRow=0x000000017459a5b0, indexPath=0xc000000000400016) at XLFormViewController.m:281
    frame #9: 0x00000001067b2248 XLForm`-[XLFormSectionDescriptor observeValueForKeyPath:ofObject:change:context:](self=0x00000001744d5cb0, _cmd="observeValueForKeyPath:ofObject:change:context:", keyPath=@"formRows", object=0x00000001744d5cb0, change=0x0000000175e753c0, context=0x0000000000000000) at XLFormSectionDescriptor.m:243
    frame #10: 0x00000001927e8d08 Foundation`NSKeyValueNotifyObserver + 304
    frame #11: 0x00000001927e8830 Foundation`NSKeyValueDidChange + 404
    frame #12: 0x000000019284be14 Foundation`-[NSObject(NSKeyValueObserverNotification) didChange:valuesAtIndexes:forKey:] + 124
    frame #13: 0x000000019289bd74 Foundation`NSKVOInsertObjectAtIndexAndNotify + 232
    frame #14: 0x00000001067b1c8c XLForm`-[XLFormSectionDescriptor showFormRow:](self=0x00000001744d5cb0, _cmd="showFormRow:", formRow=0x000000017459a5b0) at XLFormSectionDescriptor.m:219
    frame #15: 0x00000001067ac170 XLForm`-[XLFormRowDescriptor evaluateIsHidden](self=0x000000017459a5b0, _cmd="evaluateIsHidden") at XLFormRowDescriptor.m:398
    frame #16: 0x00000001067ac500 XLForm`-[XLFormRowDescriptor setHidden:](self=0x000000017459a5b0, _cmd="setHidden:", hidden=NO) at XLFormRowDescriptor.m:413
    frame #17: 0x00000001067b2be8 XLForm`-[XLFormSectionDescriptor insertObject:inAllRowsAtIndex:](self=0x00000001744d5cb0, _cmd="insertObject:inAllRowsAtIndex:", row=0x000000017459a5b0, index=2) at XLFormSectionDescriptor.m:308
    frame #18: 0x00000001067b0cd4 XLForm`-[XLFormSectionDescriptor addFormRow:](self=0x00000001744d5cb0, _cmd="addFormRow:", formRow=0x000000017459a5b0) at XLFormSectionDescriptor.m:128
```